### PR TITLE
fix(scripts): bound manual idle cleanup and transient sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ Session.vim
 
 # Explicit public command; all Daily status policy lives in its own repository.
 !/scripts/daily-paper-logs
+
+# Static idle-maintenance command and isolated regression suite.
+!/scripts/clear_sannux_transients
+!/tests/test_idle_cleanup.py

--- a/README.md
+++ b/README.md
@@ -348,12 +348,14 @@ including `.omnews-data/`, `node_modules/`, and `dist/`. This is not conflict-aw
 synchronization: concurrent edits, equal-mtime divergent files, clock differences,
 and copied Git internals can lose changes or leave inconsistent state. Stop
 agents/writers on participating directories first, including ephemeral runners.
-Pi synchronization includes the entire `~/.pi/` tree, including credentials and
-sessions; only add trusted hosts. Symlink targets and paths inside files are
-copied verbatim, not rewritten for the receiving machine.
+Pi synchronization still includes credentials, configuration, and resource
+snapshots, but excludes agent sessions; only add trusted hosts. Symlink targets
+and paths inside files are copied verbatim, not rewritten for the receiving
+machine.
 
-Hosts need SSH, rsync, Zsh, and `trash`. Directories are created relative to each
-host's own home before collection or distribution, so an empty new peer can
+Hosts need SSH, rsync, Zsh, and `trash` or GIO (`gio trash`, notably on Linux).
+Directories are created relative to each host's own home before collection or
+distribution, so an empty new peer can
 contribute nothing and then receive the collected files. Failed prerequisites,
 directory preparation, or transfers stop the script with a failing exit status.
 A failed collection prevents distribution; already completed local changes are
@@ -362,6 +364,51 @@ Unavailable hosts therefore prevent a successful complete run; no retry is made.
 Prerequisite checks depend on helper exit statuses: `pullall` currently does not
 reliably propagate individual `git pull` failures, so inspect its output. This
 script is not a clean-Git gate.
+
+### Manual idle cleanup boundary
+
+Run `synchosts` only after **all** work is idle, including audio generation,
+retries, upload, publication and deploy continuations. It does not establish
+Queue ownership or stop Pi/Omnews. A live agent-home consumer or unavailable
+local Docker inspection blocks transient cleanup, rather than being killed.
+Deploy the updated scripts to every participating host before using this path.
+
+Before transfers, every host (including additional hosts) previews
+`clear_sannux_transients`, runs `stop_omnivoicetts`, then applies transient
+cleanup. OmniVoice stop keeps its existing process-match scope: TERM, bounded
+wait, KILL if necessary, and a final no-writer check **before** generic cache
+clearing. Inspection failure or a surviving matching writer prevents clearing.
+
+`clear_sannux_transients` defaults to preview. `--apply --idle-confirmed` is the
+explicit standalone destructive mode. It removes only generated
+`~/sannux-data/agent-homes/<name>.ephemeral-runs/run.XXXXXX` directories (six
+alphanumeric suffix characters) and the contents, including hidden entries, of
+`pi-daily-paper-sessions`. It preserves that directory, namespace directories,
+and persistent Pi/Codex auth/config homes. Canonical owned roots are mandatory;
+symlinked roots and mounted subtrees are refused. Links inside disposable
+contents are unlinked, never followed. Unexpected temporary names are reported
+and preserved; custom roots outside this fixed tree are not swept.
+
+Python with symlink-safe `shutil.rmtree`, `ps`, and a reachable local Unix-socket
+Docker context are required when candidates exist. Checks are not a launcher
+lock: the operator must keep work idle until maintenance ends. There is no
+force-bypass for an uninspectable or busy owner.
+
+Sync excludes `.scratch/`, `.cache/`, `.astro/`, transient Sannux homes, Daily
+sessions, known agent session stores, Linux Daily node_modules and legacy
+Daily hook state. Exclusions apply in both directions and **do not erase old
+copies**. Incident Scratch evidence stays on its originating host. Persistent
+auth, resources, configuration, unrelated workspaces and intentional shared
+backups keep their existing transfer behavior.
+
+Daily coordinator/worker attempts, audio, consumer logs and trusted markers are
+**not generic cache** and are not removed here. Their retention belongs to
+Daily Paper's existing `maintenance/prune-runtime-history.sh`, which currently
+covers five newest runs/briefings, current-day protection and Trash. Extending
+that tool to remote TTS bundles, with active/unresolved/retry protection and
+Linux-compatible Trash, remains separate work; do not substitute `rm -rf`
+or silently drop failed attempts to make this cleanup look complete. GIO/Trash
+moves do not empty Trash or necessarily free disk space immediately.
 
 Shared data uses neither `--delete` nor deletion markers. A file removed from
 only one host can return, including from a host that was offline. For intentional

--- a/scripts/clear_sannux_transients
+++ b/scripts/clear_sannux_transients
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Explicit idle maintenance, not runtime-history retention or launcher cleanup."""
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+
+NAMESPACE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\.ephemeral-runs")
+RUN = re.compile(r"run\.[A-Za-z0-9]{6}")
+
+
+def directory(path):
+    info = path.lstat()
+    if (not stat.S_ISDIR(info.st_mode) or path.resolve() != path or
+            info.st_uid != os.getuid()):
+        raise RuntimeError(f"Refusing noncanonical, symlinked or foreign directory: {path}")
+    return info.st_dev, info.st_ino
+
+
+def plan(home):
+    home = Path(home)
+    directory(home)
+    root = home / 'sannux-data' / 'agent-homes'
+    if not root.exists() and not root.is_symlink():
+        return root, [], []
+    directory(root.parent)
+    directory(root)
+    candidates, preserved = [], []
+    for namespace in sorted(root.iterdir()):
+        if NAMESPACE.fullmatch(namespace.name):
+            directory(namespace)
+            for entry in sorted(namespace.iterdir()):
+                if RUN.fullmatch(entry.name):
+                    directory(entry)
+                    candidates.append(entry)
+                else:
+                    preserved.append(entry)
+        elif namespace.name.endswith('.ephemeral-runs'):
+            preserved.append(namespace)
+        elif namespace.name == 'pi-daily-paper-sessions':
+            directory(namespace)
+            candidates.extend(sorted(namespace.iterdir()))
+    return root, candidates, preserved
+
+
+def command(*argv):
+    return subprocess.check_output(argv, text=True, timeout=15)
+
+
+def assert_idle(root):
+    # Do not signal Pi, Omnews, Docker, or user processes. Refuse ambiguity.
+    processes = command('ps', '-axo', 'pid=,command=')
+    for line in processes.splitlines():
+        fields = line.strip().split(None, 1)
+        if len(fields) != 2 or fields[0] == str(os.getpid()):
+            continue
+        args = fields[1]
+        if ('sannux_ephemeral' in args or 'run-pi-ephemeral.sh' in args or
+                str(root) in args):
+            raise RuntimeError('A launcher or process references agent homes; maintenance is not idle')
+    endpoint = command('docker', 'context', 'inspect', '--format',
+                       '{{.Endpoints.docker.Host}}').strip()
+    if not endpoint.startswith('unix://') or (os.environ.get('DOCKER_HOST') and
+            not os.environ['DOCKER_HOST'].startswith('unix://')):
+        raise RuntimeError('A reachable local Unix-socket Docker context is required')
+    ids = command('docker', 'ps', '-q').split()
+    for ident in ids:
+        records = json.loads(command('docker', 'inspect', ident))
+        if len(records) != 1:
+            raise RuntimeError('Ambiguous container inspection')
+        for mount in records[0].get('Mounts', []):
+            source = Path(mount['Source']).resolve()
+            if source == root or root in source.parents or source in root.parents:
+                raise RuntimeError(f'Container {ident} mounts agent homes; refusing cleanup')
+
+
+def validate_tree(path):
+    # Never cross a mounted filesystem or follow a link inside a disposable tree.
+    if path.is_symlink() or not path.is_dir():
+        return
+    if os.path.ismount(path):
+        raise RuntimeError(f'Refusing mounted directory: {path}')
+    for current, dirs, _ in os.walk(path, followlinks=False):
+        for name in dirs:
+            child = Path(current) / name
+            if not child.is_symlink() and os.path.ismount(child):
+                raise RuntimeError(f'Refusing mounted directory: {child}')
+
+
+def clean(home, apply=False, idle_check=assert_idle):
+    root, entries, preserved = plan(home)
+    if not entries:
+        return entries, preserved
+    idle_check(root)
+    identities = {}
+    parents = {}
+    for entry in entries:
+        parents[entry.parent] = directory(entry.parent)
+        s = entry.lstat()
+        identities[entry] = (s.st_dev, s.st_ino, s.st_mode)
+        validate_tree(entry)
+    if apply:
+        if not shutil.rmtree.avoids_symlink_attacks:
+            raise RuntimeError('This Python lacks symlink-safe directory removal')
+        idle_check(root)
+        for parent, identity in parents.items():
+            if directory(parent) != identity:
+                raise RuntimeError('Cleanup parent changed after validation')
+        # This is deliberately manual, quiescent maintenance. The checks are
+        # not a lock against a new launcher: keep all work idle until it ends.
+        for entry in entries:
+            if directory(entry.parent) != parents[entry.parent]:
+                raise RuntimeError('Cleanup parent changed after validation')
+            s = entry.lstat()
+            if (s.st_dev, s.st_ino, s.st_mode) != identities[entry]:
+                raise RuntimeError('Cleanup entry changed after validation')
+            if stat.S_ISDIR(s.st_mode):
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()  # Includes symlinks themselves, never their targets.
+    return entries, preserved
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--apply', action='store_true')
+    parser.add_argument('--idle-confirmed', action='store_true',
+                        help='Operator confirms all work and publication continuations are idle')
+    args = parser.parse_args()
+    if args.apply and not args.idle_confirmed:
+        parser.error('--apply requires --idle-confirmed; this command never stops consumers')
+    try:
+        entries, preserved = clean(Path.home(), args.apply)
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as error:
+        parser.exit(1, f'Cleanup refused: {error}\n')
+    verb = 'Removed' if args.apply else 'Would remove'
+    for entry in entries:
+        print(f'{verb}: {entry}')
+    for entry in preserved:
+        print(f'Preserved unexpected entry: {entry}')
+    print(f'{verb} {len(entries)} entries; persistent homes and session directory preserved.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/stop_omnivoicetts
+++ b/scripts/stop_omnivoicetts
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+pattern='/[o]mnivoicetts'
 
-clear_tts_cache
-pkill -9 -f '/[o]mnivoicetts' >/dev/null 2>&1 || true
+workers_running() {
+  local result=0
+  pgrep -f "$pattern" >/dev/null || result=$?
+  case "$result" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) printf 'Cannot inspect OmniVoice workers; refusing cache cleanup.\n' >&2; exit "$result" ;;
+  esac
+}
+
+signal_workers() {
+  local result=0
+  pkill "$1" -f "$pattern" >/dev/null 2>&1 || result=$?
+  [[ "$result" == 0 || "$result" == 1 ]] || return "$result"
+}
+
+# Preserve the existing match scope. Never kill Pi/Omnews to make cleanup pass.
+# Graceful stop first, then bounded escalation; never clear under a writer.
+if workers_running; then
+  signal_workers -TERM
+  for attempt in 1 2 3 4 5; do
+    sleep 1
+    workers_running || break
+  done
+  if workers_running; then
+    signal_workers -9
+    sleep 1
+  fi
+fi
+if workers_running; then
+  printf 'OmniVoice workers remain; refusing cache cleanup.\n' >&2
+  exit 1
+fi
+"$script_dir/clear_tts_cache"

--- a/scripts/synchosts
+++ b/scripts/synchosts
@@ -17,8 +17,12 @@ for host in "${sync_hosts[@]}"; do
 done
 sync_hosts=("${peers[@]}")
 
-if ! command -v trash >/dev/null 2>&1; then
-  print -u2 -- 'trash is required; no synchronization was started.'
+if command -v trash >/dev/null 2>&1; then
+  trash_command=(trash)
+elif command -v gio >/dev/null 2>&1; then
+  trash_command=(gio trash --)
+else
+  print -u2 -- 'trash or gio is required; no synchronization was started.'
   exit 1
 fi
 
@@ -27,15 +31,20 @@ if [[ -o interactive ]]; then
   fc -W || exit $?
 fi
 
+# Manual idle maintenance only. Refuse live agent-home consumers before stops
+# or synchronization. All peers need the updated helper before this is used.
+"$host_runner" "$@" -- '"$HOME/dotfiles/scripts/clear_sannux_transients"' || exit $?
+
 "$script_dir/zsh_history_sync.py" "$@" || exit $?
 "$HOME"/.tmux/plugins/tmux-resurrect/scripts/save.sh || exit $?
 
-"$host_runner" 'stop_omnivoicetts' || exit $?
+"$host_runner" "$@" -- '"$HOME/dotfiles/scripts/stop_omnivoicetts"' || exit $?
+"$host_runner" "$@" -- '"$HOME/dotfiles/scripts/clear_sannux_transients" --apply --idle-confirmed' || exit $?
 
 # Include hidden entries and symlinks, but keep the live parent directory.
 resurrect_entries=("$HOME"/.local/share/tmux/resurrect/*(DN))
 if (( ${#resurrect_entries[@]} )); then
-  trash "${resurrect_entries[@]}" || exit $?
+  "${trash_command[@]}" "${resurrect_entries[@]}" || exit $?
 fi
 
 sleep 5 || exit $?
@@ -50,6 +59,9 @@ echo
 prline
 
 project_excludes=(
+  --exclude='.scratch/'
+  --exclude='.cache/'
+  --exclude='.astro/'
   --exclude='node_modules/'
   --exclude='.omnews-data/'
   --exclude='otaviomiranda.com.br/run_dir/'
@@ -82,7 +94,7 @@ resurrect_stage="${resurrect_stage:A}"
 cleanup_stage() {
   local result=$?
   trap - EXIT
-  if [[ -d "$resurrect_stage" ]] && ! trash "$resurrect_stage"; then
+  if [[ -d "$resurrect_stage" ]] && ! "${trash_command[@]}" "$resurrect_stage"; then
     print -u2 -- "Cannot move staged tmux snapshot to Trash: $resurrect_stage"
     (( result != 0 )) || result=1
   fi
@@ -139,7 +151,19 @@ sync_data_home() {
   if [[ "$directory" == "$projects_directory" ]]; then
     excludes+=(--exclude='tutoriais_e_cursos/')
   elif [[ "$directory" == "$pi_directory" ]]; then
-    excludes+=(--exclude='agent/extensions/**/node_modules/')
+    excludes+=(--exclude='agent/extensions/**/node_modules/'
+      --exclude='/agent/sessions/')
+  elif [[ "$directory" == 'sannux-data/' ]]; then
+    excludes+=(--exclude='/agent-homes/*.ephemeral-runs/'
+      --exclude='/agent-homes/pi-daily-paper-sessions/'
+      --exclude='/agent-homes/*/.pi-resources.*/'
+      --exclude='/agent-homes/*/.pi/agent/sessions/'
+      --exclude='/agent-homes/*/.codex/sessions/'
+      --exclude='/agent-homes/*/.codex/archived_sessions/'
+      --exclude='/workspaces/pi-daily-paper-node-modules/')
+  elif [[ "$directory" == '.codex/automations/' ]]; then
+    excludes+=(--exclude='/*/hooks/state/'
+      --exclude='/*/hooks/on-end/tts/*.json')
   fi
   sync_home "$directory" "$route" "${excludes[@]}"
 }
@@ -164,12 +188,18 @@ if [[ -f "$HOME/.zshrc" ]]; then
   # Check the required executable below instead of trusting the profile status.
   source "$HOME/.zshrc" >/dev/null 2>&1 || :
 fi
-command -v trash >/dev/null 2>&1 || { print -u2 "trash is required on this host"; exit 1; }
+if command -v trash >/dev/null 2>&1; then
+  trash_command=(trash)
+elif command -v gio >/dev/null 2>&1; then
+  trash_command=(gio trash --)
+else
+  print -u2 "trash or gio is required on this host"; exit 1
+fi
 directory="$HOME/.local/share/tmux/resurrect"
 mkdir -p "$directory" || exit 1
 entries=("$directory"/*(DN))
 if (( ${#entries[@]} )); then
-  trash "${entries[@]}"
+  "${trash_command[@]}" "${entries[@]}"
 fi'
   "$host_runner" --host "$host" --no-tty "zsh -f -c ${(qq)remote_script}"
 }

--- a/tests/test_idle_cleanup.py
+++ b/tests/test_idle_cleanup.py
@@ -1,0 +1,180 @@
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+loader = importlib.machinery.SourceFileLoader('cleanup', str(ROOT / 'scripts/clear_sannux_transients'))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+cleanup = importlib.util.module_from_spec(spec)
+loader.exec_module(cleanup)
+
+
+class CleanupTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name).resolve()
+        self.root = self.home / 'sannux-data/agent-homes'
+        self.run = self.root / 'pi.ephemeral-runs/run.ABC123'
+        self.run.mkdir(parents=True)
+        (self.run / '.auth').write_text('fixture')
+        self.sessions = self.root / 'pi-daily-paper-sessions'
+        self.sessions.mkdir()
+        (self.sessions / '.hidden').write_text('fixture')
+        (self.sessions / 'nested').mkdir()
+        self.persistent = self.root / 'pi/auth.json'
+        self.persistent.parent.mkdir()
+        self.persistent.write_text('persistent fixture')
+
+    def test_preview_and_apply_preserve_persistent_homes_and_parent(self):
+        idle = lambda root: None
+        cleanup.clean(self.home, idle_check=idle)
+        self.assertTrue(self.run.exists())
+        cleanup.clean(self.home, True, idle)
+        self.assertFalse(self.run.exists())
+        self.assertEqual(list(self.sessions.iterdir()), [])
+        self.assertEqual(self.persistent.read_text(), 'persistent fixture')
+
+    def test_symlink_child_removed_without_following_target(self):
+        (self.sessions / 'link').symlink_to(self.persistent.parent, target_is_directory=True)
+        cleanup.clean(self.home, True, lambda root: None)
+        self.assertTrue(self.persistent.exists())
+
+    def test_symlink_namespace_rejected_before_any_deletion(self):
+        (self.root / 'codex.ephemeral-runs').symlink_to(self.persistent.parent)
+        with self.assertRaises(RuntimeError):
+            cleanup.clean(self.home, True, lambda root: None)
+        self.assertTrue(self.run.exists())
+
+    def test_symlink_session_root_rejected(self):
+        shutil.rmtree(self.sessions)
+        self.sessions.symlink_to(self.persistent.parent)
+        with self.assertRaises(RuntimeError):
+            cleanup.clean(self.home, True, lambda root: None)
+        self.assertTrue(self.persistent.exists())
+
+    def test_unknown_names_and_history_are_not_cleanup_targets(self):
+        unknown = self.run.parent / 'run.too-long'
+        unknown.mkdir()
+        history = self.home / '.local/state/daily-paper-tts/attempt'
+        history.mkdir(parents=True)
+        entries, preserved = cleanup.clean(self.home, True, lambda root: None)
+        self.assertIn(unknown, preserved)
+        self.assertTrue(history.exists())
+        self.assertTrue(unknown.exists())
+
+    def test_busy_owner_aborts_without_deletion(self):
+        def busy(root):
+            raise RuntimeError('busy')
+        with self.assertRaises(RuntimeError):
+            cleanup.clean(self.home, True, busy)
+        self.assertTrue(self.run.exists())
+
+    def test_changed_parent_is_rejected_at_apply_boundary(self):
+        calls = []
+        def idle(root):
+            calls.append(root)
+            if len(calls) == 2:
+                self.run.parent.rename(self.root / 'saved-fixture')
+                (self.root / 'pi.ephemeral-runs').symlink_to(self.persistent.parent)
+        with self.assertRaises(RuntimeError):
+            cleanup.clean(self.home, True, idle)
+        self.assertTrue(self.persistent.exists())
+        self.assertTrue((self.sessions / '.hidden').exists())
+
+    def test_foreign_owner_is_rejected(self):
+        with patch.object(cleanup.os, 'getuid', return_value=os.getuid() + 10000):
+            with self.assertRaises(RuntimeError):
+                cleanup.clean(self.home, True, lambda root: None)
+        self.assertTrue(self.run.exists())
+
+    def test_mount_is_rejected_before_deletion(self):
+        with patch.object(cleanup.os.path, 'ismount', return_value=True):
+            with self.assertRaises(RuntimeError):
+                cleanup.clean(self.home, True, lambda root: None)
+        self.assertTrue(self.run.exists())
+
+    def test_container_bind_and_remote_context_are_rejected(self):
+        def fake(*args):
+            if args[0] == 'ps':
+                return ''
+            if args[1] == 'context':
+                return 'unix:///fixture.sock'
+            if args[1] == 'ps':
+                return 'fixture-container'
+            return json.dumps([{'Mounts': [{'Source': str(self.run)}]}])
+        with patch.object(cleanup, 'command', side_effect=fake):
+            with self.assertRaisesRegex(RuntimeError, 'mounts agent homes'):
+                cleanup.assert_idle(self.root)
+        with patch.object(cleanup, 'command', side_effect=['', 'ssh://remote']):
+            with self.assertRaisesRegex(RuntimeError, 'local Unix-socket'):
+                cleanup.assert_idle(self.root)
+
+    def test_unavailable_inspection_fails_closed(self):
+        with patch.object(cleanup, 'command', side_effect=OSError('unavailable')):
+            with self.assertRaises(OSError):
+                cleanup.clean(self.home, True)
+        self.assertTrue(self.run.exists())
+
+    def test_apply_requires_operator_confirmation(self):
+        result = subprocess.run([sys.executable, str(ROOT / 'scripts/clear_sannux_transients'), '--apply'],
+                                env={**os.environ, 'HOME': str(self.home)}, capture_output=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertTrue(self.run.exists())
+
+
+class StopTests(unittest.TestCase):
+    def scenario(self, mode):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            shutil.copy2(ROOT / 'scripts/stop_omnivoicetts', root / 'stop')
+            fake = root / 'fake'
+            fake.write_text(f'#!{sys.executable}\n' + '''import pathlib,sys,os
+root=pathlib.Path(os.environ['FIXTURE'])
+name=pathlib.Path(sys.argv[0]).name
+with (root/'log').open('a') as f: f.write(name+' '+ ' '.join(sys.argv[1:])+'\\n')
+mode=os.environ['MODE']
+if name=='pgrep':
+ if mode=='error': sys.exit(2)
+ sys.exit(1 if (root/'stopped').exists() else 0)
+if name=='pkill' and mode!='stuck':
+ if mode=='graceful' or '-9' in sys.argv: (root/'stopped').touch()
+''')
+            fake.chmod(0o755)
+            for name in ['pgrep', 'pkill', 'sleep', 'clear_tts_cache']:
+                (root / name).symlink_to(fake)
+            result = subprocess.run(['/bin/bash', str(root / 'stop')],
+                                    env={**os.environ, 'FIXTURE': str(root), 'MODE': mode,
+                                         'PATH': f'{root}:/usr/bin:/bin'},
+                                    capture_output=True, text=True, timeout=10)
+            return result.returncode, (root / 'log').read_text()
+
+    def test_stop_precedes_clear(self):
+        rc, log = self.scenario('graceful')
+        self.assertEqual(rc, 0)
+        self.assertLess(log.index('pkill -TERM'), log.index('clear_tts_cache'))
+        self.assertNotIn('pkill -9', log)
+
+    def test_escalation_is_bounded_and_preserves_match_scope(self):
+        rc, log = self.scenario('escalate')
+        self.assertEqual(rc, 0)
+        self.assertIn('pkill -9 -f /[o]mnivoicetts', log)
+        self.assertLess(log.index('pkill -9'), log.index('clear_tts_cache'))
+
+    def test_stuck_or_uninspectable_workers_never_clear(self):
+        for mode in ['stuck', 'error']:
+            rc, log = self.scenario(mode)
+            self.assertNotEqual(rc, 0)
+            self.assertNotIn('clear_tts_cache', log)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_synchosts.py
+++ b/tests/test_synchosts.py
@@ -65,6 +65,8 @@ class SyncHostsTests(unittest.TestCase):
             "if name==os.environ.get('FAIL_COMMAND'): sys.exit(17)\n"
             "if name=='hostname': print(os.environ.get('FAKE_HOST','m132')); sys.exit(0)\n"
             "if name in ['sleep','pullall','prline','stop_omnivoicetts']: sys.exit(0)\n"
+            "if name=='gio':\n"
+            " assert args[:2]==['trash','--']; args=args[2:]; name='trash'\n"
             "if name in ['trash','rm']:\n"
             " if os.environ.get('FAIL_TRASH') and name=='trash': sys.exit(9)\n"
             " store=root/'trash'; store.mkdir(exist_ok=True)\n"
@@ -75,7 +77,8 @@ class SyncHostsTests(unittest.TestCase):
             " sys.exit(0)\n"
             "if name=='ssh':\n"
             " host,command=args[-2:]; home=root/'homes'/host\n"
-            " if command=='stop_omnivoicetts': sys.exit(0)\n"
+            " if 'scripts/clear_sannux_transients' in command: sys.exit(19 if os.environ.get('FAIL_IDLE') else 0)\n"
+            " if 'scripts/stop_omnivoicetts' in command: sys.exit(0)\n"
             " if '.zsh_history' in command: print(': 100:0;echo fixture'); sys.exit(0)\n"
             " env={**os.environ,'HOME':str(home),'ZDOTDIR':str(home)}\n"
             " if host==os.environ.get('FAIL_REMOTE_TRASH') and 'trash' in command: env['FAIL_TRASH']='1'\n"
@@ -92,7 +95,7 @@ class SyncHostsTests(unittest.TestCase):
             "raise SystemExit('Unexpected fixture command '+name)\n"
         )
         fake.chmod(0o755)
-        for name in ["hostname", "sleep", "pullall", "prline", "ssh", "rsync", "trash", "rm", "stop_omnivoicetts"]:
+        for name in ["hostname", "sleep", "pullall", "prline", "ssh", "rsync", "trash", "gio", "rm", "stop_omnivoicetts"]:
             (self.bin / name).symlink_to(fake)
         for name in ["python3", "python3.14"]:
             (self.bin / name).symlink_to(sys.executable)
@@ -149,6 +152,60 @@ class SyncHostsTests(unittest.TestCase):
         data_copies = [c for c in copies if "tmux/resurrect" not in c[-1]]
         phases = ["pull" if ":~/" in c[-2] else "push" for c in data_copies]
         self.assertEqual(phases, sorted(phases))
+
+    def test_transient_data_is_not_copied_but_persistent_auth_and_resources_are(self):
+        transient = [
+            'Desktop/tutoriais_e_cursos/project/.scratch/evidence',
+            'Desktop/tutoriais_e_cursos/project/.cache/data',
+            '.codex/automations/daily/hooks/state/marker',
+            '.pi/agent/sessions/conversation',
+            'sannux-data/agent-homes/pi.ephemeral-runs/run.ABC123/auth',
+            'sannux-data/agent-homes/pi-daily-paper-sessions/.hidden',
+            'sannux-data/agent-homes/pi/.pi/agent/sessions/session',
+            'sannux-data/workspaces/pi-daily-paper-node-modules/package',
+        ]
+        durable = ['sannux-data/agent-homes/pi/.pi/agent/auth.json',
+                   'sannux-data/agent-homes/codex/.codex/auth.json',
+                   'sannux-data/agent-homes/pi/.pi/agent/RESOURCE_SNAPSHOT',
+                   'sannux-data/workspaces/user-project/code']
+        origin = self.root / 'homes/m4128'
+        for rel in transient + durable:
+            f = origin / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text('fixture only')
+        result = self.run_sync()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for rel in transient:
+            self.assertTrue((origin / rel).exists())
+            self.assertFalse((self.home / rel).exists(), rel)
+        for rel in durable:
+            self.assertTrue((self.home / rel).exists(), rel)
+
+    def test_gio_fallback_uses_only_mocked_trash(self):
+        # Force backend selection in this copied fixture script, never hide a
+        # real tool and accidentally invoke the operator's desktop Trash.
+        source = self.script.read_text()
+        self.assertEqual(source.count('if command -v trash >/dev/null 2>&1; then'), 2)
+        self.script.write_text(source.replace('if command -v trash >/dev/null 2>&1; then', 'if false; then'))
+        result = self.run_sync()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(any(c[0] == 'gio' for c in self.commands()))
+
+    def test_idle_failure_stops_before_stop_or_copy(self):
+        result = self.run_sync(extra_env={'FAIL_IDLE': '1'})
+        self.assertEqual(result.returncode, 19, result.stderr)
+        self.assertFalse(any(c[0] == 'rsync' or any('stop_omnivoicetts' in a for a in c)
+                             for c in self.commands()))
+
+    def test_additional_host_gets_idle_stop_and_apply_in_order(self):
+        result = self.run_sync('--additional-hosts', 'extra')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [c[-1] for c in self.commands() if c[0] == 'ssh' and c[-2] == 'extra']
+        relevant = [c for c in calls if 'scripts/clear_sannux_transients' in c or 'scripts/stop_omnivoicetts' in c]
+        self.assertEqual(len(relevant), 3)
+        self.assertNotIn('--apply', relevant[0])
+        self.assertIn('stop_omnivoicetts', relevant[1])
+        self.assertIn('--apply --idle-confirmed', relevant[2])
 
     def test_newest_file_is_collected_before_distribution(self):
         for host, text, timestamp in [("m132", "old", 100), ("m4128", "middle", 200), ("fedoraair", "newest", 300)]:


### PR DESCRIPTION
## Scope
- Stop existing matching OmniVoice processes before clearing generic caches; refuse surviving/uninspectable writers.
- Preview-first exact-root Sannux transient/session cleanup; preserve persistent auth/config homes and session parent; refuse live consumers and symlinked roots.
- Apply the idle sequence to all selected hosts, including additional hosts.
- Exclude transient homes, sessions, caches, private Scratch evidence and known runtime state from both sync directions, preserving intended persistent auth/resources/configuration and unrelated workspaces.
- Support GIO Trash for existing tmux cleanup on Linux.

## Validation
- 15 isolated cleanup/stop tests passed.
- 15 mocked-transport synchosts tests passed, including real rsync only between temporary fixture trees.
- Bash/Zsh syntax, allowlist and staged diff checks passed.
- No real stop, cleanup, Trash, synchronization, deployment or active-consumer change was executed.

## Release boundary
Static candidate only. Do not deploy or invoke while audio, upload, publication or deploy continuation remains active. Parent/operator must verify terminal state and authorize deployment separately.

Daily TTS attempts/audio/markers/logs remain outside generic cache cleanup. Extending the existing Daily-owned keep-five/current-day/Trash retention to resolved remote bundles remains separate work; no duplicate retention policy is introduced here.